### PR TITLE
Add support for Holocene

### DIFF
--- a/trello/plugins/mississippi_calendar.py
+++ b/trello/plugins/mississippi_calendar.py
@@ -77,6 +77,10 @@ def main(trello, secrets):
             'url': 'http://danteslive.com/calendar/',
             'venue': "Dante's",
         },
+        {
+            'url': 'http://www.holocene.org/calendar',
+            'venue': 'Holocene',
+        },
     ]
 
     for site in sites:


### PR DESCRIPTION
Turns out the Mississippi scraper works for Holocene's calendar. Of
course, a subset of the events are already on Mississippi's calendar,
but many are missing. Not sure how it is decided which events show up
on other venue's calendars.

Fixes #10 