### PR TITLE
Initial Py3 Port

### DIFF
--- a/trello/plugins/sync_to_trello.py
+++ b/trello/plugins/sync_to_trello.py
@@ -275,7 +275,6 @@ def sync_to_trello(trello, secrets, song_objects, force_add=None):
                 card.set_label(label)
 
             for comment in comments:
-                comment.decode('utf-8', 'ignore')
                 card.add_comment(comment)
 
         show.pop('_internal')
@@ -322,15 +321,15 @@ def add(trello, secrets):
         readline.set_completer_delims('')
         final_value = None
         if default:
-            value = raw_input("{} (Default: {}): ".format(item, default))
+            value = input("{} (Default: {}): ".format(item, default))
         else:
-            value = raw_input("{}: ".format(item))
+            value = input("{}: ".format(item))
         if value:
             if tp in [list]:
                 final_value = []
                 while value:
                     final_value.append(value)
-                    value = raw_input("{} (more): ".format(item))
+                    value = input("{} (more): ".format(item))
             elif tp is datetime.datetime:
                 for splitter in ['/', '-', ' ']:
                     if len(value.split(splitter)) == 3:
@@ -364,13 +363,13 @@ def add(trello, secrets):
         }
         print('----------------------------------------')
         pprint.pprint(event)
-        if raw_input("Confirm event [Y/n]").lower() == 'n':
+        if input("Confirm event [Y/n]").lower() == 'n':
             print("Press enter to keep the default value. Otherwise provide your changes.")
             continue
         events.append(event)
         event = {}
         print('')
-        continue_interview = raw_input("Add another event? [Y/n]").lower() != 'n'
+        continue_interview = input("Add another event? [Y/n]").lower() != 'n'
 
     sync_to_trello(trello, secrets, events, force_add=True)
 

--- a/trello/plugins/wonderballroom.py
+++ b/trello/plugins/wonderballroom.py
@@ -3,7 +3,7 @@
 
 from __future__ import print_function
 
-from urlparse import urljoin
+from urllib.parse import urljoin
 
 import arrow
 import requests

--- a/trello/trello.py
+++ b/trello/trello.py
@@ -8,7 +8,7 @@ import imp
 
 from trollop.lib import TrelloConnection
 
-import secret
+import trello.secret as secret
 
 import warnings
 warnings.filterwarnings("ignore")


### PR DESCRIPTION
Fixes #13

Note: I hadn't considered until writing the commit that you meant
supporting both Py2 AND Py3. If that's the goal, this doesn't do that...

Everything seems to be working with very minimal changes.

1) One use of str.decode, which Py3 doesn't support. Removed.
2) Some imports changed
3) Module loading is slightly different, so secrets import is different
as well
4) raw_input() became input()