### PR TITLE
Basic very simple POC of adding Travis to find broken scrapers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - "2.7"
+# Handle git submodules yourself
+git:
+    submodules: false
+# Use sed to replace the SSH URL with the public URL, then initialize submodules
+before_install:
+    - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+    - git submodule update --init --recursive
+
+install: "python setup.py develop"
+script: "sync_trello test"

--- a/trello/plugins/mississippi_calendar.py
+++ b/trello/plugins/mississippi_calendar.py
@@ -27,10 +27,6 @@ sites = [
         'venue': 'Aladdin Theater',
     },
     {
-        'url': 'http://danteslive.com/calendar/',
-        'venue': "Dante's",
-    },
-    {
         'url': 'http://www.holocene.org/calendar',
         'venue': 'Holocene',
     },

--- a/trello/plugins/mississippi_calendar.py
+++ b/trello/plugins/mississippi_calendar.py
@@ -9,6 +9,33 @@ import requests
 from bs4 import BeautifulSoup as bs
 from trello.plugins.sync_to_trello import sync_to_trello
 
+sites = [
+    {
+        'url': 'http://www.mississippistudios.com/calendar',
+        'venue': 'Mississippi Studios',
+    },
+    {
+        'url': 'http://www.dougfirlounge.com/calendar',
+        'venue': 'Doug Fir Lounge',
+    },
+    {
+        'url': 'http://www.revolutionhall.com/calendar',
+        'venue': 'Revolution Hall',
+    },
+    {
+        'url': 'http://www.aladdin-theater.com/calendar',
+        'venue': 'Aladdin Theater',
+    },
+    {
+        'url': 'http://danteslive.com/calendar/',
+        'venue': "Dante's",
+    },
+    {
+        'url': 'http://www.holocene.org/calendar',
+        'venue': 'Holocene',
+    },
+]
+
 def parse_event(event, default_venue=None):
     over_21 = event.find(class_='over-21') is not None
 
@@ -55,63 +82,53 @@ def parse_event(event, default_venue=None):
     return fobj
 
 
-def main(trello, secrets):
-    sites = [
-        {
-            'url': 'http://www.mississippistudios.com/calendar',
-            'venue': 'Mississippi Studios',
-        },
-        {
-            'url': 'http://www.dougfirlounge.com/calendar',
-            'venue': 'Doug Fir Lounge',
-        },
-        {
-            'url': 'http://www.revolutionhall.com/calendar',
-            'venue': 'Revolution Hall',
-        },
-        {
-            'url': 'http://www.aladdin-theater.com/calendar',
-            'venue': 'Aladdin Theater',
-        },
-        {
-            'url': 'http://danteslive.com/calendar/',
-            'venue': "Dante's",
-        },
-        {
-            'url': 'http://www.holocene.org/calendar',
-            'venue': 'Holocene',
-        },
-    ]
-
-    for site in sites:
-        url = site['url']
-        venue = site['venue']
-        print("Scanning {}... ".format(venue), end='')
-        content = requests.get(url)
-        doc = bs(content.text, 'html.parser')
-        days = doc.select('.vevent.data')
-        final_events = []
-        for day in days:
-            time_str = day.find('span').get('title')
-            date = arrow.get(time_str)
-            events = day.find_all('div', class_='one-event')
-            for event in events:
-                parsed_event = parse_event(event, venue)
-                start_time = event.find(class_='start-time')
-                if start_time:
-                    start_time = start_time.text.lower()
-                    ampm = start_time.split(' ')[-1]
-                    parts = start_time.split(' ')[0].split(':')
-                    hours = int(parts[0])
-                    mins = int(parts[1])
-                    if ampm.startswith('p'):
-                        hours += 12
-                    date = date.replace(hour=hours % 24, minute=mins % 60)
-                parsed_event['date'] = date
-                final_events.append(parsed_event)
-        print("Found {} items.".format(len(final_events)))
-        sync_to_trello(trello, secrets, final_events)
+def main(site):
+    url = site['url']
+    venue = site['venue']
+    content = requests.get(url)
+    doc = bs(content.text, 'html.parser')
+    days = doc.select('.vevent.data')
+    final_events = []
+    for day in days:
+        time_str = day.find('span').get('title')
+        date = arrow.get(time_str)
+        events = day.find_all('div', class_='one-event')
+        for event in events:
+            parsed_event = parse_event(event, venue)
+            start_time = event.find(class_='start-time')
+            if start_time:
+                start_time = start_time.text.lower()
+                ampm = start_time.split(' ')[-1]
+                parts = start_time.split(' ')[0].split(':')
+                hours = int(parts[0])
+                mins = int(parts[1])
+                if ampm.startswith('p'):
+                    hours += 12
+                date = date.replace(hour=hours % 24, minute=mins % 60)
+            parsed_event['date'] = date
+            final_events.append(parsed_event)
+    return final_events
 
 
 def run(trello, secrets):
-    main(trello, secrets)
+    final_events = []
+    for site in sites:
+        print("Scanning {}... ".format(site['venue']), end='')
+        events = main(site)
+        print("Found {} items.".format(len(events)))
+        final_events.extend(events)
+    sync_to_trello(trello, secrets, final_events)
+    return [True]
+
+
+def tester(site):
+    events = main(site)
+    if len(events) == 0:
+        print("ERROR: No results for {}".format(site['venue']))
+        return False
+    else:
+        return True
+
+
+def test(trello, secrets):
+    return [tester(site) for site in sites]

--- a/trello/plugins/seen_bands.py
+++ b/trello/plugins/seen_bands.py
@@ -3,4 +3,4 @@
 
 
 def run(trello, secrets):
-    pass
+    return [True]

--- a/trello/trello.py
+++ b/trello/trello.py
@@ -21,6 +21,7 @@ def cli():
         secret.key['trello']['api_key'],
         secret.key['trello']['token'])
 
+    results = []
     plugins = [x
                for x in glob.glob('trello/plugins/*.py')
                if '__init__' not in x]
@@ -31,7 +32,10 @@ def cli():
         if hasattr(plug, action):
             method = getattr(plug, action)
             if callable(method):
-                method(trello, secret.key)
+                result = method(trello, secret.key)
+                results.extend(result)
+    if not all(results):
+        sys.exit(1)
 
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
https://travis-ci.org/rattboi/trello-concert-tracker/builds/252935511

Note that it's properly failing now, because the Dante's scraper in the Mississippi plugin isn't working.

I had to refactor quite a bit to break out a test cli function. Also, there's quite a bit of duplication starting to build up. It makes sense to me to create an abstract base class we subclass for these scrapers, or something along those lines. That'd also allow us to unify the heuristics bits for scraping together artist info, which is distributed across each, and are each a bit different.

Paired w/ a cron Travis job, that should inform us fairly quickly when one of the scrapers starts to fail.

